### PR TITLE
fix php spec tests

### DIFF
--- a/spec/SM/DummyObject.php
+++ b/spec/SM/DummyObject.php
@@ -9,7 +9,7 @@ class DummyObject
 
     }
 
-    public function setState()
+    public function setState($state)
     {
 
     }


### PR DESCRIPTION
due to this change:
https://github.com/symfony/PropertyAccess/commit/bd0fcd19b63ea4b25054f4275045c45bddae1dc2

`it_applies_transition` spec didn't work as the `PropertyAccessor` finds that the number of args given for `setState` didn't match the actually implementation.
