### PR TITLE
Allow the 'all_transitions' key in the 'on' clause

### DIFF
--- a/src/SM/Callback/Callback.php
+++ b/src/SM/Callback/Callback.php
@@ -100,6 +100,10 @@ class Callback implements CallbackInterface
      */
     protected function isSatisfiedByClause($clause, $value)
     {
+        if ( $clause == 'on' && in_array('all_transitions', $this->specs[$clause]) ) {
+            return true;
+        }
+
         if (0 < count($this->specs[$clause]) && !in_array($value, $this->specs[$clause])) {
             return false;
         }


### PR DESCRIPTION
Not sure if this is a general use case, but I've found myself trying to use a callback for all available transitions (and find it annoying listing the one by one). Let's say, for example, I want to create a log for an entity, that keeps all the transitions it had made till its actual state. 

Thus, It would be nice to have something like:

``` yaml
callbacks:
   callbacks:
          after:
              log_activity:
                  on: 'all_transitions'
                  do: something
```

So, this is what I propose in this PR. :smile: 
