### PR TITLE
Additional data can be used when getting the state for a transition

### DIFF
--- a/spec/SM/Callback/CascadeTransitionCallbackSpec.php
+++ b/spec/SM/Callback/CascadeTransitionCallbackSpec.php
@@ -26,7 +26,7 @@ class CascadeTransitionCallbackSpec extends ObjectBehavior
         $factory->get($object, 'graph')->willReturn($sm);
 
         $sm->can('transition')->willReturn(true);
-        $sm->apply('transition', true)->shouldBeCalled();
+        $sm->apply('transition', array(), true)->shouldBeCalled();
 
         $this->apply($object, $event, 'transition', 'graph');
     }
@@ -45,7 +45,7 @@ class CascadeTransitionCallbackSpec extends ObjectBehavior
         $factory->get($object, 'graph')->willReturn($sm1);
 
         $sm1->can('transition')->willReturn(true);
-        $sm1->apply('transition', true)->shouldBeCalled();
+        $sm1->apply('transition', array(), true)->shouldBeCalled();
 
         $this->apply($object, $event, 'transition');
     }
@@ -65,7 +65,7 @@ class CascadeTransitionCallbackSpec extends ObjectBehavior
         $factory->get($object, 'graph')->willReturn($sm1);
 
         $sm1->can('transition')->willReturn(true);
-        $sm1->apply('transition', true)->shouldBeCalled();
+        $sm1->apply('transition', array(), true)->shouldBeCalled();
 
         $this->apply($object, $event);
     }

--- a/spec/SM/StateMachine/StateMachineSpec.php
+++ b/spec/SM/StateMachine/StateMachineSpec.php
@@ -128,7 +128,7 @@ class StateMachineSpec extends ObjectBehavior
 
         $dispatcher->dispatch(Argument::any())->shouldNotBeCalled();
 
-        $this->apply('confirm', true);
+        $this->apply('confirm', array(), true);
     }
 
     function it_throws_an_exception_if_transition_doesnt_exist_on_apply()

--- a/src/SM/Callback/CascadeTransitionCallback.php
+++ b/src/SM/Callback/CascadeTransitionCallback.php
@@ -41,9 +41,10 @@ class CascadeTransitionCallback
      * @param TransitionEvent    $event      Transition event
      * @param string|null        $transition Transition that is to be applied (if null, same as the trigger)
      * @param string|null        $graph      Graph on which the new transition will apply (if null, same as the trigger)
+     * @param array              $data       Additional data to use when getting state
      * @param bool               $soft       If true, check if it can apply the transition first (no Exception thrown)
      */
-    public function apply($objects, TransitionEvent $event, $transition = null, $graph = null, $soft = true)
+    public function apply($objects, TransitionEvent $event, $transition = null, $graph = null, array $data = array(), $soft = true)
     {
         if (!is_array($objects) && !$objects instanceof \Traversable) {
             $objects = array($objects);
@@ -58,7 +59,7 @@ class CascadeTransitionCallback
         }
 
         foreach ($objects as $object) {
-            $this->factory->get($object, $graph)->apply($transition, $soft);
+            $this->factory->get($object, $graph)->apply($transition, $data, $soft);
         }
     }
 }

--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -111,7 +111,7 @@ class StateMachine implements StateMachineInterface
     /**
      * {@inheritDoc}
      */
-    public function apply($transition, $soft = false)
+    public function apply($transition, array $data = array(), $soft = false)
     {
         if (!$this->can($transition)) {
             if ($soft) {
@@ -135,7 +135,9 @@ class StateMachine implements StateMachineInterface
 
         $this->callCallbacks($event, 'before');
 
-        $this->setState($this->config['transitions'][$transition]['to']);
+        $this->setState(
+            $this->getStateForTransition($transition, $data)
+        );
 
         $this->callCallbacks($event, 'after');
 
@@ -180,6 +182,11 @@ class StateMachine implements StateMachineInterface
             array_keys($this->config['transitions']),
             array($this, 'can')
         );
+    }
+
+    protected function getStateForTransition($transition, array $data = array())
+    {
+        return $this->config['transitions'][$transition]['to'];
     }
 
     /**

--- a/src/SM/StateMachine/StateMachineInterface.php
+++ b/src/SM/StateMachine/StateMachineInterface.php
@@ -30,13 +30,14 @@ interface StateMachineInterface
      * Applies the transition on the underlying object
      *
      * @param string $transition Transition to apply
+     * @param array  $data       Additional data to use when getting state
      * @param bool   $soft       Soft means do nothing if transition can't be applied (no exception thrown)
      *
      * @return bool If the transition has been applied or not (in case of soft apply)
      *
      * @throws SMException If transition can't be applied or doesn't exist
      */
-    public function apply($transition, $soft = false);
+    public function apply($transition, array $data = array(), $soft = false);
 
     /**
      * Returns the current state


### PR DESCRIPTION
Hi there,

First of all props for the amazing library! It works perfectly with states as string. But in my use case, I would like to store some additional data alongside the state of the object like the datetime of when the object has transitioned to state.
To store such information, I made the state an entity instead of a string. And by overriding the new `getStateForTransition` method in my own StateMachine class, I can return an object instead of a string. To add data to the state object, you can pass an additional array.

Hopefully you'll like the idea :-) otherwise you have some thoughts how I can resolve this with your library.
