### PR TITLE
Change callCallbacks to be 5.3 compatible

### DIFF
--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -221,7 +221,7 @@ class StateMachine implements StateMachineInterface
                 $callback = $this->callbackFactory->get($callback);
             }
 
-            $callback($event);
+            call_user_func($callback, $event);
         }
     }
 }


### PR DESCRIPTION
Not sure if you're interested in maintaining 5.3 compatability, but we need it.
