### PR TITLE
Fixed twig 1.12 deprecations

### DIFF
--- a/src/SM/Extension/Twig/SMExtension.php
+++ b/src/SM/Extension/Twig/SMExtension.php
@@ -34,7 +34,7 @@ class SMExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'sm_can' => new \Twig_Function_Method($this, 'can'),
+            new \Twig_SimpleFunction('sm_can', array($this, 'can')),
         );
     }
 


### PR DESCRIPTION
Twig_Function_Method is deprecated and will be removed