### PR TITLE
Add sm_state and sm_possible_transitions to twig extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,12 @@
         "symfony/property-access":     "~2.1",
         "symfony/expression-language": "~2.4"
     },
+    "suggest": {
+        "twig/twig": "Access the state machine in your twig templates (~1.0)"
+    },
     "require-dev": {
-        "phpspec/phpspec": "~2.0"
+        "phpspec/phpspec": "~2.0",
+        "twig/twig": "~1.0"
     },
     "autoload": {
         "psr-0": { "SM": "src/" }

--- a/spec/SM/Extension/Twig/SMExtensionSpec.php
+++ b/spec/SM/Extension/Twig/SMExtensionSpec.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace spec\SM\Extension\Twig;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use spec\SM\DummyObject;
+
+class SMExtensionSpec extends ObjectBehavior
+{
+    function let(FactoryInterface $factory, StateMachineInterface $stateMachine)
+    {
+        $this->beConstructedWith($factory);
+        $factory->get(new DummyObject(), 'simple')->willReturn($stateMachine);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('SM\Extension\Twig\SMExtension');
+    }
+
+    function it_is_a_twig_extension()
+    {
+        $this->shouldBeAnInstanceOf('\Twig_Extension');
+    }
+
+    function it_should_have_a_name()
+    {
+        $this->getName()->shouldReturn('sm');
+    }
+
+    function it_provide_sm_can_function(FactoryInterface $factory, StateMachineInterface $stateMachine)
+    {
+        $this->can($object = new DummyObject(), 'new', 'simple');
+
+        $factory->get($object, 'simple')->shouldHaveBeenCalled();
+        $stateMachine->can('new')->shouldHaveBeenCalled();
+    }
+
+    function it_provide_sm_getState_function(FactoryInterface $factory, StateMachineInterface $stateMachine)
+    {
+        $this->getState($object = new DummyObject(), 'simple');
+
+        $factory->get($object, 'simple')->shouldHaveBeenCalled();
+        $stateMachine->getState()->shouldHaveBeenCalled();
+    }
+
+    function it_provide_sm_getPossibleTransitions_function(FactoryInterface $factory, StateMachineInterface $stateMachine)
+    {
+        $this->getPossibleTransitions($object = new DummyObject(), 'simple');
+
+        $factory->get($object, 'simple')->shouldHaveBeenCalled();
+        $stateMachine->getPossibleTransitions()->shouldHaveBeenCalled();
+    }
+}

--- a/src/SM/Extension/Twig/SMExtension.php
+++ b/src/SM/Extension/Twig/SMExtension.php
@@ -35,6 +35,8 @@ class SMExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFunction('sm_can', array($this, 'can')),
+            new \Twig_SimpleFunction('sm_state', array($this, 'getState')),
+            new \Twig_SimpleFunction('sm_possible_transitions', array($this, 'getPossibleTransitions')),
         );
     }
 
@@ -48,6 +50,28 @@ class SMExtension extends \Twig_Extension
     public function can($object, $transition, $graph = 'default')
     {
         return $this->factory->get($object, $graph)->can($transition);
+    }
+
+    /**
+     * @param object $object
+     * @param string $graph
+     *
+     * @return string
+     */
+    public function getState($object, $graph = 'default')
+    {
+        return $this->factory->get($object, $graph)->getState();
+    }
+
+    /**
+     * @param object $object
+     * @param string $graph
+     *
+     * @return array
+     */
+    public function getPossibleTransitions($object, $graph = 'default')
+    {
+        return $this->factory->get($object, $graph)->getPossibleTransitions();
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR add two functions in the twig extension.

`sm_state` : Returns the current state
`sm_possible_transitions` : Returns the possible transitions
