### PR TITLE
soft option for can function

### DIFF
--- a/spec/SM/StateMachine/StateMachineSpec.php
+++ b/spec/SM/StateMachine/StateMachineSpec.php
@@ -85,6 +85,11 @@ class StateMachineSpec extends ObjectBehavior
         $this->shouldThrow('SM\\SMException')->during('can', array('non-existing-transition'));
     }
 
+    function it_does_nothing_if_transition_doesnt_exist_in_soft_mode()
+    {
+        $this->can('foobar', true)->shouldReturn(false);
+    }
+
     function it_applies_transition(
         $object,
         $dispatcher,
@@ -134,6 +139,11 @@ class StateMachineSpec extends ObjectBehavior
     function it_throws_an_exception_if_transition_doesnt_exist_on_apply()
     {
         $this->shouldThrow('SM\\SMException')->during('apply', array('non-existing-transition'));
+    }
+
+    function it_does_nothing_if_transition_doesnt_exist_on_apply_in_soft_mode()
+    {
+        $this->apply('foobar', true)->shouldReturn(false);
     }
 
     function it_returns_current_state($object)

--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -83,9 +83,14 @@ class StateMachine implements StateMachineInterface
     /**
      * {@inheritDoc}
      */
-    public function can($transition)
+    public function can($transition, $soft = false)
     {
         if (!isset($this->config['transitions'][$transition])) {
+
+            if($soft) {
+                return false;
+            }
+
             throw new SMException(sprintf(
                 'Transition %s does not exist on object %s with graph %s',
                 $transition,
@@ -113,7 +118,7 @@ class StateMachine implements StateMachineInterface
      */
     public function apply($transition, $soft = false)
     {
-        if (!$this->can($transition)) {
+        if (!$this->can($transition, $soft)) {
             if ($soft) {
                 return false;
             }


### PR DESCRIPTION
Hello,

While using this state machine I ran into the problem of trying to apply transitions using soft mode and still having errors be thrown.  The soft mode works if the transition exists, but I think it should also work if the transition doesn't exist at all.  I thought that if the purpose of a soft mode for applying a transition is to make it so it doesn't throw an error, then it should be consistent and not throw an error even if it doesn't exist.

If you don't agree then that is ok, I already worked around this in my application very easily, but just thought I would make a pull request for fun to see what you think.