### PR TITLE
Quote string values in scalars

### DIFF
--- a/src/SM/Factory/AbstractFactory.php
+++ b/src/SM/Factory/AbstractFactory.php
@@ -54,7 +54,7 @@ abstract class AbstractFactory implements FactoryInterface
         }
 
         throw new SMException(sprintf(
-            'Cannot create a state machine because the configuration for object %s with graph %s does not exist.',
+            'Cannot create a state machine because the configuration for object "%s" with graph "%s" does not exist.',
             get_class($object),
             $graph
         ));
@@ -76,7 +76,7 @@ abstract class AbstractFactory implements FactoryInterface
 
         if (!isset($config['class'])) {
             throw new SMException(sprintf(
-               'Index "class" needed for the state machine configuration of graph %s',
+               'Index "class" needed for the state machine configuration of graph "%s"',
                 $config['graph']
             ));
         }

--- a/src/SM/Factory/Factory.php
+++ b/src/SM/Factory/Factory.php
@@ -49,7 +49,7 @@ class Factory extends AbstractFactory
             $class = $config['state_machine_class'];
         } else {
             throw new SMException(sprintf(
-               'Class %s for creating a new state machine does not exist.',
+               'Class "%s" for creating a new state machine does not exist.',
                 $config['state_machine_class']
             ));
         }

--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -72,7 +72,7 @@ class StateMachine implements StateMachineInterface
             $this->getState();
         } catch (NoSuchPropertyException $e) {
             throw new SMException(sprintf(
-               'Cannot access to configured property path %s on object %s with graph %s',
+               'Cannot access to configured property path "%s" on object %s with graph "%s"',
                 $config['property_path'],
                 get_class($object),
                 $config['graph']
@@ -87,7 +87,7 @@ class StateMachine implements StateMachineInterface
     {
         if (!isset($this->config['transitions'][$transition])) {
             throw new SMException(sprintf(
-                'Transition %s does not exist on object %s with graph %s',
+                'Transition "%s" does not exist on object "%s" with graph "%s"',
                 $transition,
                 get_class($this->object),
                 $this->config['graph']
@@ -119,7 +119,7 @@ class StateMachine implements StateMachineInterface
             }
 
             throw new SMException(sprintf(
-                'Transition %s cannot be applied on state %s of object %s with graph %s',
+                'Transition "%s" cannot be applied on state "%s" of object "%s" with graph "%s"',
                 $transition,
                 $this->getState(),
                 get_class($this->object),
@@ -197,7 +197,7 @@ class StateMachine implements StateMachineInterface
     {
         if (!in_array($state, $this->config['states'])) {
             throw new SMException(sprintf(
-                'Cannot set the state to %s to object %s with graph %s because it is not pre-defined.',
+                'Cannot set the state to "%s" to object "%s" with graph %s because it is not pre-defined.',
                 $state,
                 get_class($this->object),
                 $this->config['graph']


### PR DESCRIPTION
Currently exceptions can be confusing, e.g.


```
Transition commit cannot be applied on state assigned of object 
```

Can take some decoding before you realise that `commit` is the transition and `assigned` is the state the object is in. This PR adds quotes to all string values in exceptions:

```
Transition "commit" cannot be applied on state "assigned" of object 
```