### PR TITLE
Added guards for transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ $config = array(
         )
     ),
     'callbacks' => array(
+        'guard' => array(
+            'guard-cancel' => array(
+                'to' => array('cancelled'), // Will be called only for transitions going to this state
+                'do' => function() { var_dump('guarding to cancelled state'); return false; }
+            )
+        ),
         'before' => array(
             'from-checkout' => array(
                 'from' => array('checkout'), // Will be called only for transitions coming from this state
@@ -87,7 +93,9 @@ Please refer to the several examples in the `examples` folder.
 
 #### Callbacks
 
-Callbacks are used to execute some code before or after applying transitions.
+Callbacks are used to guard transitions or execute some code before or after applying transitions.
+
+Guarding callbacks must return a `bool`. If a guard returns `false`, a transition cannot be performed.
 
 
 ##### Credits

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -36,6 +36,12 @@ $config = array(
         )
     ),
     'callbacks' => array(
+        'guard' => array(
+            'guard-cancel' => array(
+                'to' => array('cancelled'), // Will be called only for transitions going to this state
+                'do' => function() { var_dump('guarding to cancelled state'); return false; }
+            )
+        ),
         'before' => array(
             'from-checkout' => array(
                 'from' => array('checkout'), // Will be called only for transitions coming from this state
@@ -89,4 +95,10 @@ var_dump($stateMachine->getState());
 var_dump($stateMachine->apply('confirm'));
 
 // Current state is confirmed
+var_dump($stateMachine->getState());
+
+// Returns false, as it is guarded
+var_dump($stateMachine->can('cancel'));
+
+// Current state is still confirmed
 var_dump($stateMachine->getState());

--- a/src/SM/Callback/Callback.php
+++ b/src/SM/Callback/Callback.php
@@ -76,6 +76,7 @@ class Callback implements CallbackInterface
         if ($this->isSatisfiedBy($event)) {
             return $this->call($event);
         }
+        return true;
     }
 
     /**

--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -218,17 +218,17 @@ class StateMachine implements StateMachineInterface
      */
     protected function callCallbacks(TransitionEvent $event, $position)
     {
-        $result = true;
         if (!isset($this->config['callbacks'][$position])) {
-            return $result;
+            return true;
         }
 
+        $result = true;
         foreach ($this->config['callbacks'][$position] as &$callback) {
             if (!$callback instanceof CallbackInterface) {
                 $callback = $this->callbackFactory->get($callback);
             }
 
-            $result = $result & call_user_func($callback, $event);
+            $result = call_user_func($callback, $event) && $result;
         }
         return $result;
     }


### PR DESCRIPTION
Hey,
thank you for your great project. While using it, I learned that guards can currently only be implemented by listening to the `TEST_TRANSITION` event. I then found winzou/StateMachineBundle#8 and would also prefer guards as explicit members of the state machine configuration.

So, I added guards to the state machine and hope, that you consider merging this to your project. Feel free to comment on the code and please give me some feedback,

thanks, best regards,
Christian A. Wolf