### PR TITLE
Allow callback to call object method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ $config = array(
             'to-cancelled' => array(
                 'to' => array('cancelled'), // Will be called only for transitions going to this state
                 'do' => function() { var_dump('to cancel transition'); }
-            )
+            ),
+            'cancel-date' => array(
+                'to' => array('cancelled'),
+                'do' => array('object', 'setCancelled'),
+            ),
         )
     )
 );

--- a/examples/DomainObject.php
+++ b/examples/DomainObject.php
@@ -33,4 +33,9 @@ class DomainObject
     {
         $this->stateB = $state;
     }
+
+    public function setConfirmedNow()
+    {
+        var_dump('I (the object) am set confirmed at '.date('Y-m-d').'.');
+    }
 }

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -50,7 +50,11 @@ $config = array(
             'to-cancelled' => array(
                 'to' => array('cancelled'), // Will be called only for transitions going to this state
                 'do' => function() { var_dump('to cancel transition'); }
-            )
+            ),
+            'confirm-date' => array(
+                'on' => array('confirm'),
+                'do' => array('object', 'setConfirmedNow'), // 'object' will be replaced by the object undergoing the transition
+            ),
         )
     )
 );
@@ -86,6 +90,7 @@ var_dump($stateMachine->getState());
 
 // Return true, this transition is applied
 // In addition, callback 'on-confirm' is called
+// And callback 'confirm-date' calls the method 'setConfirmedNow' on the object itself
 var_dump($stateMachine->apply('confirm'));
 
 // Current state is confirmed

--- a/src/SM/Callback/Callback.php
+++ b/src/SM/Callback/Callback.php
@@ -122,7 +122,7 @@ class Callback implements CallbackInterface
      */
     protected function filterCallable($callable, TransitionEvent $event)
     {
-        if (is_array($callable) && isset($callable[0]) && 'object' === substr($callable[0], 0, 6)) {
+        if (is_array($callable) && isset($callable[0]) && is_string($callable[0]) && 'object' === substr($callable[0], 0, 6)) {
             $object = $event->getStateMachine()->getObject();
 
             // callable could be "object.property" and not just "object", so we evaluate the "property" path

--- a/src/SM/Callback/Callback.php
+++ b/src/SM/Callback/Callback.php
@@ -13,6 +13,7 @@ namespace SM\Callback;
 
 use SM\Event\TransitionEvent;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class Callback implements CallbackInterface
 {
@@ -65,7 +66,9 @@ class Callback implements CallbackInterface
             );
         }
 
-        return call_user_func_array($this->callable, $args);
+        $callable = $this->filterCallable($this->callable, $event);
+
+        return call_user_func_array($callable, $args);
     }
 
     /**
@@ -109,5 +112,28 @@ class Callback implements CallbackInterface
         }
 
         return true;
+    }
+
+    /**
+     * @param callable|array  $callable A callable or array with index 0 starting with "object" that will evaluated as a property path with "object" being the object undergoing the transition
+     * @param TransitionEvent $event
+     *
+     * @return callable
+     */
+    protected function filterCallable($callable, TransitionEvent $event)
+    {
+        if (is_array($callable) && isset($callable[0]) && 'object' === substr($callable[0], 0, 6)) {
+            $object = $event->getStateMachine()->getObject();
+
+            // callable could be "object.property" and not just "object", so we evaluate the "property" path
+            if ('object' !== $callable[0]) {
+                $accessor = new PropertyAccessor();
+                $object = $accessor->getValue($object, substr($callable[0], 7));
+            }
+
+            return array($object, $callable[1]);
+        }
+
+        return $callable;
     }
 }


### PR DESCRIPTION
Now if you define a callback as `array('object', 'method')`, the callback will call the method `method` on the object undergoing the transition. You can also use `array('object.property', 'otherMethod')` to call `otherMethod` on the property `$object->getProperty()` (using property accessor).

Very useful!