### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,20 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - hhvm
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
+  allow_failures:
+    - php: 5.3
+      dist: xenial
+    - php: 5.3
+      dist: trusty
 
 before_script:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php":                         ">=5.3.0",
-        "symfony/event-dispatcher":    "~2.1|~3.0",
-        "symfony/property-access":     "~2.1|~3.0",
-        "symfony/expression-language": "~2.4|~3.0"
+        "symfony/event-dispatcher":    "~2.1|~3.0|~4.0",
+        "symfony/property-access":     "~2.1|~3.0|~4.0",
+        "symfony/expression-language": "~2.4|~3.0|~4.0"
     },
     "suggest": {
         "twig/twig": "Access the state machine in your twig templates (~1.0)"


### PR DESCRIPTION
Hello there,

I have added Symfony 4.0+ compatibility in `composer.json`, and made some little changes in `.travis.yml`file.

Can you please merge and tag a new version? I suggest 0.3.3, since there's no BC break.

Thank you,
Ben