### PR TITLE
Add getPossibleNextStates() method to StateMachine

### DIFF
--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -72,7 +72,7 @@ class StateMachine implements StateMachineInterface
             $this->getState();
         } catch (NoSuchPropertyException $e) {
             throw new SMException(sprintf(
-               'Cannot access to configured property path "%s" on object %s with graph "%s"',
+                'Cannot access to configured property path "%s" on object %s with graph "%s"',
                 $config['property_path'],
                 get_class($object),
                 $config['graph']
@@ -185,6 +185,22 @@ class StateMachine implements StateMachineInterface
             array_keys($this->config['transitions']),
             array($this, 'can')
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPossibleNextStates()
+    {
+        $nextStates = array($this->getState());
+
+        $possibleTransitions = $this->getPossibleTransitions();
+
+        foreach ($possibleTransitions as $transition) {
+            $nextStates[] = $this->config['transitions'][$transition]['to'];
+        }
+        
+        return $nextStates;
     }
 
     /**

--- a/src/SM/StateMachine/StateMachineInterface.php
+++ b/src/SM/StateMachine/StateMachineInterface.php
@@ -65,4 +65,11 @@ interface StateMachineInterface
      * @return array
      */
     public function getPossibleTransitions();
+
+    /**
+     * Returns the possible next states
+     *
+     * @return array
+     */
+    public function getPossibleNextStates();
 }


### PR DESCRIPTION
Add an extra method that returns an array of the possible next states from the current state (which include the current state of course).

Could be useful in admin crud use cases