### PR TITLE
Make nullable arguments explicit

### DIFF
--- a/src/SM/Factory/Factory.php
+++ b/src/SM/Factory/Factory.php
@@ -31,8 +31,8 @@ class Factory extends AbstractFactory
 
     public function __construct(
         array $configs,
-        EventDispatcherInterface $dispatcher      = null,
-        CallbackFactoryInterface $callbackFactory = null
+        ?EventDispatcherInterface $dispatcher      = null,
+        ?CallbackFactoryInterface $callbackFactory = null
     ) {
         parent::__construct($configs);
 

--- a/src/SM/StateMachine/StateMachine.php
+++ b/src/SM/StateMachine/StateMachine.php
@@ -36,18 +36,18 @@ class StateMachine implements StateMachineInterface
     protected $callbackFactory;
 
     /**
-     * @param object                   $object          Underlying object for the state machine
-     * @param array                    $config          Config array of the graph
-     * @param EventDispatcherInterface $dispatcher      EventDispatcher or null not to dispatch events
-     * @param CallbackFactoryInterface $callbackFactory CallbackFactory or null to use the default one
+     * @param object                        $object          Underlying object for the state machine
+     * @param array                         $config          Config array of the graph
+     * @param EventDispatcherInterface|null $dispatcher      EventDispatcher or null not to dispatch events
+     * @param CallbackFactoryInterface|null $callbackFactory CallbackFactory or null to use the default one
      *
      * @throws SMException If object doesn't have configured property path for state
      */
     public function __construct(
         $object,
         array $config,
-        EventDispatcherInterface $dispatcher      = null,
-        CallbackFactoryInterface $callbackFactory = null
+        ?EventDispatcherInterface $dispatcher      = null,
+        ?CallbackFactoryInterface $callbackFactory = null
     ) {
         $this->object          = $object;
         $this->dispatcher      = $dispatcher;


### PR DESCRIPTION
Not specifying nullable variables explicitly is deprecated since PHP 8.4, which can result in not-so-nice-to-look-at deprecation warnings 😅 