### PR TITLE
[DX] Test against newer PHP versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,12 @@ jobs:
                     - php: "8.2"
                       symfony: "~7.0"
 
+                    - php: "8.3"
+                      symfony: "~7.0"
+
+                    - php: "8.4"
+                      symfony: "~7.0"
+
         steps:
             -
                 uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "twig/twig": "Access the state machine in your twig templates (^2.10|^3.0)"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.0|^6.0|^7.1",
+        "phpspec/phpspec": "^5.0|^6.0|^7.1|^8.0",
         "twig/twig": "^2.10|^3.0"
     },
     "autoload": {


### PR DESCRIPTION
As the library technically supports PHP 8.3 and 8.4 (I've only needed to add the newer PHPSpec version to composer) it would be nice to have it in the pipeline :) 